### PR TITLE
Add image-focused menu and new art slider

### DIFF
--- a/art.html
+++ b/art.html
@@ -38,45 +38,28 @@
     /* ---------- PAGE TITLE ---------- */
     .page-title { font-size: 2em; font-weight: 700; text-align: center; margin: 40px 0 16px; letter-spacing: 0.05em; color: #E10600; }
 
-    /* ---------- GALLERY GRID ---------- */
-    .gallery {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 20px;
-      margin-top: 32px;
-    }
-    .gallery-item {
+    /* ---------- FULLSCREEN SLIDER ---------- */
+    .slider {
       position: relative;
-      background-size: cover;
-      background-position: center;
-      height: 0;
-      padding-bottom: 75%; /* 4:3 ratio */
+      width: 100%;
+      height: 100vh;
       overflow: hidden;
-      cursor: pointer;
-      border-radius: 8px;
-      box-shadow: 0 4px 24px rgba(0,0,0,0.3);
-      transition: transform .3s, box-shadow .3s;
     }
-    .gallery-item:hover {
-      transform: scale(1.03);
-      box-shadow: 0 6px 32px rgba(0,0,0,0.5);
-    }
-    .gallery-caption {
+    .slide {
       position: absolute;
-      bottom: 0;
+      top: 0;
       left: 0;
       width: 100%;
-      background: rgba(0,0,0,0.6);
-      color: #fff;
-      text-align: center;
-      padding: 8px 4px;
-      font-size: 1em;
-      letter-spacing: .04em;
+      height: 100%;
+      background-size: cover;
+      background-position: center;
       opacity: 0;
-      transition: opacity .3s;
+      transform: scale(1.1);
+      transition: opacity 1.5s ease, transform 8s linear;
     }
-    .gallery-item:hover .gallery-caption {
+    .slide.active {
       opacity: 1;
+      transform: scale(1);
     }
 
     /* ---------- SECTION TEXT ---------- */
@@ -145,24 +128,12 @@
     </p>
   </div>
 
-  <!-- GALLERY GRID -->
-  <div class="container">
-    <div class="gallery">
-      <!-- アイテムごとに背景画像を差し替えてください -->
-      <div class="gallery-item" style="background-image: url('images/art/photo (1).jpg');" tabindex="0">
-        <div class="gallery-caption">作品タイトル 1</div>
-      </div>
-      <div class="gallery-item" style="background-image: url('images/art/photo (2).jpg');" tabindex="0">
-        <div class="gallery-caption">作品タイトル 2</div>
-      </div>
-      <div class="gallery-item" style="background-image: url('images/art/photo (3).jpg');" tabindex="0">
-        <div class="gallery-caption">作品タイトル 3</div>
-      </div>
-      <div class="gallery-item" style="background-image: url('images/art/photo (4).jpg');" tabindex="0">
-        <div class="gallery-caption">作品タイトル 4</div>
-      </div>
-      <!-- 追加する場合は同じ構造をコピーして background-image のパスとキャプションを変更してください -->
-    </div>
+  <!-- FULLSCREEN SLIDER -->
+  <div class="slider">
+    <div class="slide active" style="background-image: url('images/art/photo (1).jpg');"></div>
+    <div class="slide" style="background-image: url('images/art/photo (2).jpg');"></div>
+    <div class="slide" style="background-image: url('images/art/photo (3).jpg');"></div>
+    <div class="slide" style="background-image: url('images/art/photo (4).jpg');"></div>
   </div>
 
   <!-- RESERVE BUTTON -->
@@ -190,11 +161,22 @@
 
   <!-- ---------- SCRIPTS ---------- -->
   <script>
+    /* ---------------- SLIDER ---------------- */
+    document.addEventListener('DOMContentLoaded', () => {
+      const slides = document.querySelectorAll('.slide');
+      let idx = 0;
+      setInterval(() => {
+        slides[idx].classList.remove('active');
+        idx = (idx + 1) % slides.length;
+        slides[idx].classList.add('active');
+      }, 5000);
+    });
+
     /* ---------------- CUSTOM CURSOR ---------------- */
     document.addEventListener('DOMContentLoaded', () => {
       const cursorDot = document.querySelector('.cursor-dot');
       const cursorOutline = document.querySelector('.cursor-dot-outline');
-      const hoverables = document.querySelectorAll('a, button, .reserve-btn, .gallery-item');
+      const hoverables = document.querySelectorAll('a, button, .reserve-btn, .slide');
       let mouseX = 0, mouseY = 0, outlineX = 0, outlineY = 0, dotX = 0, dotY = 0;
       const trails = [], trailCount = 15;
       for (let i = 0; i < trailCount; i++) {

--- a/menu.html
+++ b/menu.html
@@ -38,20 +38,20 @@
     /* ---------- PAGE TITLE ---------- */
     .page-title { font-size: 2em; font-weight: 700; text-align: center; margin: 40px 0 16px; letter-spacing: 0.05em; color: #E10600; }
 
-    /* ---------- MENU LIST ---------- */
-    .menu-category { margin-top: 32px; }
-    .menu-category h3 {
-      font-size: 1.3em; font-weight: 700; margin-bottom: 12px; color: #fff; letter-spacing: .04em;
+    /* ---------- MENU GALLERY ---------- */
+    .menu-gallery {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 20px;
+      margin-top: 32px;
     }
-    .menu-list {
-      list-style: none; padding: 0; margin: 0 0 24px;
+    .menu-gallery img {
+      width: 100%;
+      height: 200px;
+      object-fit: cover;
+      border-radius: 8px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.3);
     }
-    .menu-list li {
-      display: flex; justify-content: space-between; padding: 8px 0;
-      border-bottom: 1px solid rgba(255,255,255,0.1);
-      font-size: 1.05em; line-height: 1.6;
-    }
-    .menu-list li span.price { color: #E10600; font-weight: 700; }
 
     /* ---------- RESERVE BUTTON ---------- */
     .reserve-btn {
@@ -115,60 +115,17 @@
 
   <!-- MENU CONTENT -->
   <div class="container">
-    <!-- Food Menu -->
-    <div class="menu-category">
-      <h3>Food — フード</h3>
-      <ul class="menu-list">
-        <li>ガーリックトースト <span class="price">600円</span></li>
-        <li>ピザトースト <span class="price">600円</span></li>
-        <li>ハニーバタートースト <span class="price">600円</span></li>
-        <li>ガーリックチーズトースト <span class="price">600円</span></li>
-        <li>ナチョスチップ <span class="price">400円</span></li>
-        <li>ジャーキー <span class="price">500円</span></li>
-        <li>ミックスナッツ <span class="price">500円</span></li>
-        <li>コンビーフサンドイッチ <span class="price">500円</span></li>
-        <li>ハムチーズサンドイッチ <span class="price">500円</span></li>
-        <li>BLTサンドイッチ <span class="price">600円</span></li>
-      </ul>
-    </div>
-
-    <!-- Drink Menu -->
-    <div class="menu-category">
-      <h3>Drink — ドリンク</h3>
-      <!-- Coffee & Cocoa -->
-      <p style="font-weight:700; margin-top:16px;">coffee &amp; cocoa</p>
-      <ul class="menu-list">
-        <li>ice coffee <span class="price">500円</span></li>
-        <li>hot coffee <span class="price">450円</span></li>
-        <li>hot cocoa <span class="price">500円</span></li>
-      </ul>
-      <!-- Soft Drink -->
-      <p style="font-weight:700; margin-top:16px;">soft drink</p>
-      <ul class="menu-list">
-        <li>Cola <span class="price">400円</span></li>
-        <li>ginger ale <span class="price">400円</span></li>
-      </ul>
-      <!-- Float Drink -->
-      <p style="font-weight:700; margin-top:16px;">float drink</p>
-      <ul class="menu-list">
-        <li>Cola float <span class="price">1000円</span></li>
-        <li>melon cream float <span class="price">1000円</span></li>
-      </ul>
-      <!-- Non-Alcohol Cocktail -->
-      <p style="font-weight:700; margin-top:16px;">Non alcohol cocktail</p>
-      <ul class="menu-list">
-        <li>各種 <span class="price">800〜1000円</span></li>
-      </ul>
-      <!-- Beer & Cocktail -->
-      <p style="font-weight:700; margin-top:16px;">beer</p>
-      <ul class="menu-list">
-        <li>キリン <span class="price">700円</span></li>
-        <li>エビス <span class="price">800円</span></li>
-      </ul>
-      <p style="font-weight:700; margin-top:16px;">cocktail</p>
-      <ul class="menu-list">
-        <li>各種 <span class="price">800〜1300円</span></li>
-      </ul>
+    <div class="menu-gallery">
+      <!-- サンプル写真を表示 -->
+      <img src="images/food/LINE_ALBUM_フードメニュー_250515_1.jpg" alt="Food 1">
+      <img src="images/food/LINE_ALBUM_フードメニュー_250515_2.jpg" alt="Food 2">
+      <img src="images/food/LINE_ALBUM_フードメニュー_250515_3.jpg" alt="Food 3">
+      <img src="images/food/LINE_ALBUM_フードメニュー_250515_4.jpg" alt="Food 4">
+      <img src="images/food/LINE_ALBUM_フードメニュー_250515_5.jpg" alt="Food 5">
+      <img src="images/drink/LINE_ALBUM_ドリンクメニュー_250515_1.jpg" alt="Drink 1">
+      <img src="images/drink/LINE_ALBUM_ドリンクメニュー_250515_2.jpg" alt="Drink 2">
+      <img src="images/drink/LINE_ALBUM_ドリンクメニュー_250515_3.jpg" alt="Drink 3">
+      <img src="images/drink/LINE_ALBUM_ドリンクメニュー_250515_4.jpg" alt="Drink 4">
     </div>
 
     <!-- RESERVE BUTTON -->


### PR DESCRIPTION
## Summary
- replace long lists on menu page with a photo gallery
- show MENU images in three-column grid
- redesign art page with fullscreen slider and new animation script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845b1f9dad88333980df9fc4da555be